### PR TITLE
Changes to trex

### DIFF
--- a/Dockerfile-trex
+++ b/Dockerfile-trex
@@ -1,6 +1,6 @@
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
-ARG TREX_VERSION=2.87
+ARG TREX_VERSION=2.95
 ENV TREX_VERSION ${TREX_VERSION}
 
 # install requirements

--- a/pods/dpdk/trex/trex.yaml
+++ b/pods/dpdk/trex/trex.yaml
@@ -13,7 +13,9 @@ data:
   trex_cfg.yaml : |
     - port_limit: 2
       version: 2
-      interfaces: ["${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_1}","${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_2}"]
+      interfaces: 
+        - ${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_1}
+        - ${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_2}
       port_bandwidth_gb: ${PORT_BANDWIDTH_GB}
       port_info:
         - ip: 10.10.10.2

--- a/scripts/create-trex-config.sh
+++ b/scripts/create-trex-config.sh
@@ -17,7 +17,7 @@ done
 CPU="${CPU:1}"
 echo $CPU
 
-NODE=`lscpu | grep ${MASTER} | awk '/node0/{print "0"}{print "1"}'`
+NODE=`lscpu | grep ${MASTER}, | awk '/node0/{print "0"}{print "1"}'`
 export SOCKET="0"
 if [[ ${NODE} -eq 1 ]]
 then


### PR DESCRIPTION
1. Upgrading trex version to 2.95 and using CentOS 8 Stream since CentOS is EOL in Dockerfile
2. In Trex configMap I replaced the interfaces from an array list to an enumerated list. It was complaining when running the app
3. The script to find out the socket where the CPUs used in T-rex are running was missing a comma


Signed-off-by: Alberto Losada <alosadag@redhat.com>